### PR TITLE
Revert to read bval from PVM_DwEffBval and bvec from PVM_DwGradVec

### DIFF
--- a/brkraw/lib/loader.py
+++ b/brkraw/lib/loader.py
@@ -823,21 +823,9 @@ class BrukerLoader():
     # DTI
     @staticmethod
     def _get_bdata(method):
-        # [220201] parse the input value directly instead of final values & remove bmat
-        bval = get_value(method, 'PVM_DwBvalEach')
-        bval = [bval] if isinstance(bval, int) else bval
-        num_b0 = get_value(method, 'PVM_DwAoImages')
-        num_exp = get_value(method, 'PVM_DwNDiffExp')
-        num_dir = int((num_exp - num_b0) / len(bval))
-        bdir = get_value(method, 'PVM_DwDir')
-        bvals = np.r_[np.zeros(num_b0), np.concatenate([bval for i in np.ones(num_dir).astype(int)], axis=0)]
-        bvecs = np.concatenate([np.zeros([num_b0, 3])] + [bdir] * len(bval), axis=0).T
-        # test if results are correctly built
-        try:
-            assert(bvals.shape[0] == num_exp)
-            assert(bvecs.shape[-1] == num_exp)
-        except:
-            raise UnexpectedError('Exceptional case is reported, please report on issue at brkraw github')
+        """Extract, format, and return diffusion bval and bvec"""
+        bvals = np.array(get_value(method, 'PVM_DwEffBval'))
+        bvecs = np.array(get_value(method, 'PVM_DwGradVec').T)
         return bvals, bvecs
 
     # Generals


### PR DESCRIPTION
Fixes #90 and #95.

Changes proposed in this pull request:
- In `_get_bdata`, revert to reading bval from PVM_DwEffBval and bvec from PVM_DwGradVec. Both of these parameters should include the b0 scans correctly ordered, which solves #90. PVM_DwEffBval also contains the effective b-values, which include the effect of all applied gradients; it solves #95.

To consider: according to Bruker documentation for PV6.0.1 and PV360, PVM_DwGradVec is a parameter "specifying the diffusion gradient amplitudes in the x,y,z coordinate system".  This coordinate system (the scanner one) does not correspond to the FSL convention, which brkraw seems to be using. I'll open another issue on that topic. 

@BrkRaw/Bruker
