### PR TITLE
Add missing self attribute

### DIFF
--- a/brkraw/ui/main_win.py
+++ b/brkraw/ui/main_win.py
@@ -14,6 +14,7 @@ class MainWindow(tk.Tk):
         super(MainWindow, self).__init__(*args, **kwargs)
         self._raw = None
         self._ignore_slope = False
+        self._ignore_offset = False
         self._scan_id = None
         self._reco_id = None
         self._output = None


### PR DESCRIPTION
Initialization for self._ignore_offset is missing, causing a bug when converting in the GUI in windows

Fixes #.

Changes proposed in this pull request:
- Add missing attribute initialization
-
-


@BrkRaw/Bruker
