### PR TITLE
check if VisuAcquisitionProtocol exists before test for localizer

### DIFF
--- a/brkraw/scripts/brkraw.py
+++ b/brkraw/scripts/brkraw.py
@@ -710,9 +710,12 @@ def completeFieldsCreateFolders (df, filtered_dset, dset, multi_session, root_pa
 
 def is_localizer(pvobj, scan_id, reco_id):
     visu_pars = pvobj.get_visu_pars(scan_id, reco_id)
-    ac_proc = visu_pars.parameters['VisuAcquisitionProtocol']
-    if re.search('tripilot', ac_proc, re.IGNORECASE) or re.search('localizer', ac_proc, re.IGNORECASE):
-        return True
+    if 'VisuAcquisitionProtocol' in visu_pars.parameters:
+        ac_proc = visu_pars.parameters['VisuAcquisitionProtocol']
+        if re.search('tripilot', ac_proc, re.IGNORECASE) or re.search('localizer', ac_proc, re.IGNORECASE):
+            return True
+        else:
+            return False
     else:
         return False
 


### PR DESCRIPTION
Fixes #105 and #98 (maybe some others)

Changes proposed in this pull request:
- Check if 'VisuAcquisitionProtocol' protocol exists before executing `ac_proc = visu_pars.parameters['VisuAcquisitionProtocol']`
- 'VisuAcquisitionProtocol' is absent in MRS scans (e.g. PRESS) and DTI reconstructions (e.g. pdata/2) so they would crash. 
- If 'VisuAcquisitionProtocol' doesn't exists is_localizer() returns False
- Tested with a dataset that contained DTI reco + PRESS, these scans end up not being tallied in the .csv file when running bids_helper 


@BrkRaw/Bruker
