### PR TITLE
A few small changes

### DIFF
--- a/brkraw/lib/pvobj.py
+++ b/brkraw/lib/pvobj.py
@@ -37,8 +37,8 @@ class PvDatasetBase:
             subject = self._subject
             self.user_account   = subject.headers['OWNER']
             self.subj_id        = get_value(subject, 'SUBJECT_id')
-            self.study_id       = get_value(subject, 'SUBJECT_study_nr')
-            self.session_id     = get_value(subject, 'SUBJECT_study_name')
+            self.study_id       = get_value(subject, 'SUBJECT_study_name')
+            self.session_id     = get_value(subject, 'SUBJECT_study_nr')
             
             # [20210820] Add-paravision 360 related.
             title = subject.headers['TITLE']

--- a/brkraw/scripts/brkraw.py
+++ b/brkraw/scripts/brkraw.py
@@ -276,7 +276,7 @@ def main():
             ds_format = args.format
 
         # [220202] make compatible with csv, tsv and xlsx
-        output = '{}.{}'.format(ds_output, ds_format) 
+        output = '{}.{}'.format(ds_fname, ds_format) 
 
         Headers = ['RawData', 'SubjID', 'SessID', 'ScanID', 'RecoID', 'DataType',
                    'task', 'acq', 'ce', 'rec', 'dir', 'run', 'flip', 'mt', 'part', 'modality', 'Start', 'End']

--- a/brkraw/scripts/brkraw.py
+++ b/brkraw/scripts/brkraw.py
@@ -87,6 +87,7 @@ def main():
     bids_helper.add_argument("-j", "--json", help="create JSON syntax template for "
                                                   "parsing metadata from the header", action='store_true')
     bids_helper.add_argument("-s", "--subj", help="switch subject and study IDs", action='store_true')
+    bids_helper.add_argument("-t", "--sess", help="switch session and study ID", action='store_true')
 
     # bids_convert
     bids_convert.add_argument("input", help=input_dir_str, type=str)
@@ -265,10 +266,15 @@ def main():
 
     elif args.function == 'bids_helper':
         import pandas as pd
+        import warnings
         path = os.path.abspath(args.input)
         ds_output = os.path.abspath(args.output)
         make_json = args.json
         swap_id = args.subj
+        swap_sess = args.sess
+
+        if swap_id and swap_sess:
+            warnings.warn('\nBoth switch subject/study IDs and switch session/study ID options are on. You probably do not want this!\n')
 
         # [220202] for back compatibility
         ds_fname, ds_output_ext = os.path.splitext(ds_output)
@@ -303,15 +309,19 @@ def main():
                     pvobj = dset.pvobj
 
                     rawdata = pvobj.path
+                    
                     if swap_id:
                         subj_id = pvobj.study_id
                     else:
                         subj_id = pvobj.subj_id
 
+                    if swap_sess:
+                        sess_id = pvobj.study_id
+                    else:
+                        sess_id = pvobj.session_id
+
                     # make subj_id bids appropriate
                     subj_id = cleanSubjectID(subj_id)
-                    
-                    sess_id = pvobj.session_id
 
                     # make sess_id bids appropriate
                     sess_id = cleanSessionID(sess_id)

--- a/brkraw/scripts/brkraw.py
+++ b/brkraw/scripts/brkraw.py
@@ -86,6 +86,7 @@ def main():
     bids_helper.add_argument("-f", "--format", help="file format of BIDS dataheets. Use this option if you did not specify the extension on output. The available options are (csv/tsv/xlsx) (default: csv)", type=str, default='csv')
     bids_helper.add_argument("-j", "--json", help="create JSON syntax template for "
                                                   "parsing metadata from the header", action='store_true')
+    bids_helper.add_argument("-s", "--subj", help="switch subject and study IDs", action='store_true')
 
     # bids_convert
     bids_convert.add_argument("input", help=input_dir_str, type=str)
@@ -267,6 +268,7 @@ def main():
         path = os.path.abspath(args.input)
         ds_output = os.path.abspath(args.output)
         make_json = args.json
+        swap_id = args.subj
 
         # [220202] for back compatibility
         ds_fname, ds_output_ext = os.path.splitext(ds_output)
@@ -301,7 +303,10 @@ def main():
                     pvobj = dset.pvobj
 
                     rawdata = pvobj.path
-                    subj_id = pvobj.subj_id
+                    if swap_id:
+                        subj_id = pvobj.study_id
+                    else:
+                        subj_id = pvobj.subj_id
 
                     # make subj_id bids appropriate
                     subj_id = cleanSubjectID(subj_id)

--- a/brkraw/scripts/brkraw.py
+++ b/brkraw/scripts/brkraw.py
@@ -279,7 +279,7 @@ def main():
         output = '{}.{}'.format(ds_output, ds_format) 
 
         Headers = ['RawData', 'SubjID', 'SessID', 'ScanID', 'RecoID', 'DataType',
-                   'task', 'acq', 'ce', 'rec', 'dir', 'run', 'modality', 'Start', 'End']
+                   'task', 'acq', 'ce', 'rec', 'dir', 'run', 'flip', 'mt', 'part', 'modality', 'Start', 'End']
         df = pd.DataFrame(columns=Headers)
 
         # if the path directly contains scan files for one participant

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/scripts/env python
+#!/usr/bin/env python
 """
 Bruker PVdataset loader / converter
 """


### PR DESCRIPTION
Changes proposed in this pull request:
- Add new BIDS tags: flip, mt, and part
- Fix a bug in the bids_helper output filename (file extension appears twice)
- Switch the study and sessions IDs in the pvobj. 
- Add options to switch subject and study IDs, and session and study ID, in the bids_helper output

The flip and mt tags are required for MPM images. The part tag is necessary if working with phase/real/imaginary images.

Regarding the last two points: I'm not sure how others name their studies, but if we are doing a longitudinal study, we increment the Session number while keeping the study ID the same. We also put the actual study ID in the Animal ID/Name fields and the actual animal ID in the Study ID field. We find this makes browsing data in ParaVision easier as the Animal ID is the top level when searching for datasets in the Palette. These changes will make the pvobj attributes match the PV exam card fields but allow the user to switch them depending on their naming conventions.


@BrkRaw/Bruker
