### PR TITLE
Output None for inexistent parameter

### DIFF
--- a/brkraw/lib/utils.py
+++ b/brkraw/lib/utils.py
@@ -249,6 +249,8 @@ def meta_check_express(value, acqp, method, visu_pars):
         if k != 'Equation':
             exec('global {}'.format(k))
             val = meta_get_value(v, acqp, method, visu_pars)
+            if isinstance(val, str):
+                val = None
             exec('{} = {}'.format(k, val))
     try:
         exec("output = {}".format(value['Equation']), globals(), lcm)

--- a/brkraw/lib/utils.py
+++ b/brkraw/lib/utils.py
@@ -263,7 +263,7 @@ def meta_check_source(key_string, acqp, method, visu_pars):
     for i, ans in enumerate(key_exist):
         if ans:
             return get_value(pool[i], key_string)
-    return None
+    return key_string
 
 
 def yes_or_no(question):

--- a/brkraw/lib/utils.py
+++ b/brkraw/lib/utils.py
@@ -263,7 +263,7 @@ def meta_check_source(key_string, acqp, method, visu_pars):
     for i, ans in enumerate(key_exist):
         if ans:
             return get_value(pool[i], key_string)
-    return key_string
+    return None
 
 
 def yes_or_no(question):


### PR DESCRIPTION
Fixes #100.

Changes proposed in this pull request:
- Get `meta_check_source` to output `None` in case of an inexistent parameter
- Equivalent to reverting to the previous behaviour in the case of a B0 map, which was to output the string "Value was not specified" for EchoTime in the json file


@BrkRaw/Bruker
