### PR TITLE
add new bids tags

### DIFF
--- a/brkraw/scripts/brkraw.py
+++ b/brkraw/scripts/brkraw.py
@@ -279,7 +279,7 @@ def main():
         output = '{}.{}'.format(ds_output, ds_format) 
 
         Headers = ['RawData', 'SubjID', 'SessID', 'ScanID', 'RecoID', 'DataType',
-                   'task', 'acq', 'ce', 'rec', 'dir', 'run', 'modality', 'Start', 'End']
+                   'task', 'acq', 'ce', 'rec', 'dir', 'run', 'inv', 'flip', 'mt', 'part', 'modality', 'Start', 'End']
         df = pd.DataFrame(columns=Headers)
 
         # if the path directly contains scan files for one participant


### PR DESCRIPTION
Changes proposed in this pull request:
- Add new BIDS tags (inv, flip, mt, and part) to the bids_helper output data sheet 
- These are required for certain [anatomy imaging data](https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#anatomy-imaging-data)


@BrkRaw/Bruker
