### PR TITLE
add options to switch subject/session/study IDs

### DIFF
--- a/brkraw/lib/pvobj.py
+++ b/brkraw/lib/pvobj.py
@@ -37,8 +37,8 @@ class PvDatasetBase:
             subject = self._subject
             self.user_account   = subject.headers['OWNER']
             self.subj_id        = get_value(subject, 'SUBJECT_id')
-            self.study_id       = get_value(subject, 'SUBJECT_study_nr')
-            self.session_id     = get_value(subject, 'SUBJECT_study_name')
+            self.study_id       = get_value(subject, 'SUBJECT_study_name')
+            self.session_id     = get_value(subject, 'SUBJECT_study_nr')
             
             # [20210820] Add-paravision 360 related.
             title = subject.headers['TITLE']

--- a/brkraw/scripts/brkraw.py
+++ b/brkraw/scripts/brkraw.py
@@ -86,6 +86,8 @@ def main():
     bids_helper.add_argument("-f", "--format", help="file format of BIDS dataheets. Use this option if you did not specify the extension on output. The available options are (csv/tsv/xlsx) (default: csv)", type=str, default='csv')
     bids_helper.add_argument("-j", "--json", help="create JSON syntax template for "
                                                   "parsing metadata from the header", action='store_true')
+    bids_helper.add_argument("-s", "--subj", help="switch subject and study IDs", action='store_true')
+    bids_helper.add_argument("-t", "--sess", help="switch session and study ID", action='store_true')
 
     # bids_convert
     bids_convert.add_argument("input", help=input_dir_str, type=str)
@@ -267,6 +269,12 @@ def main():
         path = os.path.abspath(args.input)
         ds_output = os.path.abspath(args.output)
         make_json = args.json
+        swap_id = args.subj
+        swap_sess = args.sess
+
+        if swap_id and swap_sess:
+            import warnings
+            warnings.warn('\nBoth switch subject/study IDs and switch session/study ID options are on. You probably do not want this!\n')
 
         # [220202] for back compatibility
         ds_fname, ds_output_ext = os.path.splitext(ds_output)
@@ -301,12 +309,19 @@ def main():
                     pvobj = dset.pvobj
 
                     rawdata = pvobj.path
-                    subj_id = pvobj.subj_id
+                    
+                    if swap_id:
+                         subj_id = pvobj.study_id
+                    else:
+                        subj_id = pvobj.subj_id
+
+                    if swap_sess:
+                        sess_id = pvobj.study_id
+                    else:
+                        sess_id = pvobj.session_id
 
                     # make subj_id bids appropriate
                     subj_id = cleanSubjectID(subj_id)
-                    
-                    sess_id = pvobj.session_id
 
                     # make sess_id bids appropriate
                     sess_id = cleanSessionID(sess_id)


### PR DESCRIPTION
Builds on #122 .

Changes proposed in this pull request:
- add option to switch session_id and study_id (to maintain original behaviour)
- add option to switch subj_id and study_id
- gives a warning if both options are on

I'm not sure how others name their studies, but if we are doing a longitudinal study, we increment the **Session** number while keeping the study ID the same. We also put the actual study ID in the **Animal ID/Name** fields and the actual animal ID in the **Study Name** field.

We find this makes browsing data in ParaVision easier as the search hierarchy in Palette/Explorer is Subject > Session > Study. We can select a "Subject" (but in our case, a study) and all the subjects in that study appear in the "Study" dropdown menu.


@BrkRaw/Bruker
