### PR TITLE
[patch] macos remove testing python 3.8 and 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,11 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        exclude:
+          - python-version: "3.8"
+            os: macos-latest
+          - python-version: "3.9"
+            os: macos-latest
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
@@ -53,6 +58,11 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        exclude:
+          - python-version: "3.8"
+            os: macos-latest
+          - python-version: "3.9"
+            os: macos-latest
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Fixes #.

Changes proposed in this pull request:
- Remove Python 3.8 and 3.9 Testing on macOS: As per the recent updates, the latest macOS versions no longer support Python 3.8 and 3.9. For more details, see the discussion here: [actions/setup-python#808](https://github.com/actions/setup-python/issues/808)

@BrkRaw/Bruker
